### PR TITLE
Increase prespawned buttons

### DIFF
--- a/widgets/ItemButton.lua
+++ b/widgets/ItemButton.lua
@@ -158,7 +158,7 @@ end
 -- because buttons created in combat do not work well
 hooksecurefunc(addon, 'OnInitialize', function()
 	addon:Debug('Prespawning buttons')
-	containerButtonPool:PreSpawn(100)
+	containerButtonPool:PreSpawn(160)
 end)
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Fix for issue #22 suggested by zarevucky.

 160 should be the maximum possible number of bag slots currently.  Four
36 slot profession bags plus the 16 slot backpack.